### PR TITLE
Fix urls for modernisation platform

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,12 @@ task default: ["notify:expired"]
 namespace :notify do
   pages_urls = [
     "https://ministryofjustice.github.io/cloud-operations/api/pages.json",
-    "https://ministryofjustice.github.io/modernisation-platform/api/pages.json"
+    "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json"
   ]
 
   limits = {
     "https://ministryofjustice.github.io/cloud-operations/api/pages.json" => 5,
-    "https://ministryofjustice.github.io/modernisation-platform/api/pages.json" => 5
+    "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json" => 5
   }
 
   live = ENV.fetch("REALLY_POST_TO_SLACK", 0) == "1"


### PR DESCRIPTION
The ministryofjustice.github.io redirects to
user-guide.modernisation-platform...

This looks to cause issues:

```
JSON::ParserError: 783: unexpected token at '<html>
<head><title>30*** Moved Permanently</title></head>
<body>
<center><h***>30*** Moved Permanently</h***></center>
<hr><center>nginx</center>
</body>
</html>
```

Hopefully this will fix