### PR TITLE
Adds analytical platform user guidance documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,14 @@ task default: ["notify:expired"]
 namespace :notify do
   pages_urls = [
     "https://ministryofjustice.github.io/cloud-operations/api/pages.json",
-    "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json"
+    "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json",
+    "https://user-guidance.services.alpha.mojanalytics.xyz/api/pages.json"
   ]
 
   limits = {
     "https://ministryofjustice.github.io/cloud-operations/api/pages.json" => 5,
-    "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json" => 5
+    "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json" => 5,
+    "https://user-guidance.services.alpha.mojanalytics.xyz/api/pages.json" => 5
   }
 
   live = ENV.fetch("REALLY_POST_TO_SLACK", 0) == "1"


### PR DESCRIPTION
This is to enable the #analytical-platform to be notified when a document may be out of date.

It is related with the following PR https://github.com/moj-analytical-services/user-guidance/pull/201
Although it does not depend on that PR to be merged to merge this one.