### PR TITLE
Add tech documentation for the analytical platform

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,14 @@ task default: ["notify:expired"]
 namespace :notify do
   pages_urls = [
     "https://ministryofjustice.github.io/cloud-operations/api/pages.json",
-    "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json"
+    "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json",
+    "https://silver-dollop-30c6a355.pages.github.io/api/pages.json"
   ]
 
   limits = {
     "https://ministryofjustice.github.io/cloud-operations/api/pages.json" => 5,
-    "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json" => 5
+    "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json" => 5,
+    "https://silver-dollop-30c6a355.pages.github.io/api/pages.json" => 5
   }
 
   live = ENV.fetch("REALLY_POST_TO_SLACK", 0) == "1"


### PR DESCRIPTION
This should enable us at #analytical-platform to receive page review notifications that live in here: https://silver-dollop-30c6a355.pages.github.io/#welcome

I wonder if this will work because this documentation needs authentication, are there extra steps I should take to make this work?