### PR TITLE
🔗 Update Analytical Platform URLs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ namespace :notify do
     "https://ministryofjustice.github.io/hmpps-integration-api-docs/api/pages.json",
     "https://ministryofjustice.github.io/nvvs-devops/api/pages.json",
     "https://runbooks.cloud-platform.service.justice.gov.uk/api/pages.json",
-    "https://technical-documentation.data-platform.service.justice.gov.uk/api/pages.json",
+    "https://docs.analytical-platform.service.justice.gov.uk/api/pages.json",
     "https://technical-guidance.service.justice.gov.uk/api/pages.json",
     "https://user-guide.cloud-platform.service.justice.gov.uk/api/pages.json",
     "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json",
@@ -19,7 +19,7 @@ namespace :notify do
 
   limits = {
     "https://ministryofjustice.github.io/nvvs-devops/api/pages.json" => 5,
-    "https://technical-documentation.data-platform.service.justice.gov.uk/api/pages.json" => 5,
+    "https://docs.analytical-platform.service.justice.gov.uk/api/pages.json" => 5,
     "https://user-guide.modernisation-platform.service.justice.gov.uk/api/pages.json" => 5,
     "https://docs.opg.service.justice.gov.uk/api/pages.json" => 5
   }


### PR DESCRIPTION
This updates the AP url
part of https://github.com/ministryofjustice/analytical-platform/pull/4711