### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -3,6 +3,9 @@ on:
     - cron: '25 09 * * 1-5'  # 09:25 UTC, Monday to Friday
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   daniel_the_manual_spaniel:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ministryofjustice/tech-docs-monitor/security/code-scanning/2](https://github.com/ministryofjustice/tech-docs-monitor/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level (applied to all jobs) to explicitly limit the permissions of the `GITHUB_TOKEN`. Based on the workflow's operations, the minimal required permission is `contents: read`, as the workflow only checks out the repository and runs a script. No write permissions are needed.

The `permissions` block will be added at the root level of the workflow file, just below the `on` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
