### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ministryofjustice/tech-docs-monitor/security/code-scanning/1](https://github.com/ministryofjustice/tech-docs-monitor/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimum required permissions. Since the workflow only needs to read repository contents (e.g., to fetch the code and dependencies), the `contents: read` permission is sufficient. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

The `permissions` block should be added at the top level of the workflow file, just below the `on` key, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
